### PR TITLE
MdeModulePkg/XhciDxe: Reset endpoint while USB Transaction error

### DIFF
--- a/MdeModulePkg/Bus/Pci/XhciDxe/Xhci.c
+++ b/MdeModulePkg/Bus/Pci/XhciDxe/Xhci.c
@@ -825,7 +825,7 @@ XhcTransfer (
   *TransferResult = Urb->Result;
   *DataLength     = Urb->Completed;
 
-  if ((*TransferResult == EFI_USB_ERR_STALL) || (*TransferResult == EFI_USB_ERR_BABBLE)) {
+  if ((*TransferResult == EFI_USB_ERR_STALL) || (*TransferResult == EFI_USB_ERR_BABBLE) || (*TransferResult == EFI_USB_ERR_TRANSACTION_ERROR)) {
     ASSERT (Status == EFI_DEVICE_ERROR);
     RecoveryStatus = XhcRecoverHaltedEndpoint (Xhc, Urb);
     if (EFI_ERROR (RecoveryStatus)) {

--- a/MdeModulePkg/Bus/Pci/XhciDxe/XhciSched.c
+++ b/MdeModulePkg/Bus/Pci/XhciDxe/XhciSched.c
@@ -1193,7 +1193,7 @@ XhcCheckUrbResult (
         goto EXIT;
 
       case TRB_COMPLETION_USB_TRANSACTION_ERROR:
-        CheckedUrb->Result  |= EFI_USB_ERR_TIMEOUT;
+        CheckedUrb->Result  |= EFI_USB_ERR_TRANSACTION;
         CheckedUrb->Finished = TRUE;
         DEBUG ((DEBUG_ERROR, "XhcCheckUrbResult: TRANSACTION_ERROR! Completecode = %x\n", EvtTrb->Completecode));
         goto EXIT;

--- a/MdePkg/Include/Protocol/UsbIo.h
+++ b/MdePkg/Include/Protocol/UsbIo.h
@@ -50,16 +50,17 @@ typedef enum {
 //
 // USB Transfer Results
 //
-#define EFI_USB_NOERROR         0x00
-#define EFI_USB_ERR_NOTEXECUTE  0x01
-#define EFI_USB_ERR_STALL       0x02
-#define EFI_USB_ERR_BUFFER      0x04
-#define EFI_USB_ERR_BABBLE      0x08
-#define EFI_USB_ERR_NAK         0x10
-#define EFI_USB_ERR_CRC         0x20
-#define EFI_USB_ERR_TIMEOUT     0x40
-#define EFI_USB_ERR_BITSTUFF    0x80
-#define EFI_USB_ERR_SYSTEM      0x100
+#define EFI_USB_NOERROR          0x00
+#define EFI_USB_ERR_NOTEXECUTE   0x01
+#define EFI_USB_ERR_STALL        0x02
+#define EFI_USB_ERR_BUFFER       0x04
+#define EFI_USB_ERR_BABBLE       0x08
+#define EFI_USB_ERR_NAK          0x10
+#define EFI_USB_ERR_CRC          0x20
+#define EFI_USB_ERR_TIMEOUT      0x40
+#define EFI_USB_ERR_BITSTUFF     0x80
+#define EFI_USB_ERR_SYSTEM       0x100
+#define EFI_USB_ERR_TRANSACTION  0x200
 
 /**
   Async USB transfer callback routine.


### PR DESCRIPTION
https://bugzilla.tianocore.org/show_bug.cgi?id=4556

Based on XHCI spec 4.8.3, software should do the
reset endpoint while USB Transaction occur.
Also add the error code for USB Transaction error
since UEFI spec don't have the related definition.

Cc: Hao A Wu     <hao.a.wu@intel.com>
Cc: Ray Ni       <ray.ni@intel.com>
Cc: Jian J Wang  <jian.j.wang@intel.com>
Cc: Liming Gao   <gaoliming@byosoft.com.cn>
Cc: More Shih    <more.shih@intel.com>
Cc: Jenny Huang  <jenny.huang@intel.com>