### PR TITLE
MdeModulePkg/XhciDxe: Add PCD for the delay of HCRST

### DIFF
--- a/MdeModulePkg/Bus/Pci/XhciDxe/Xhci.h
+++ b/MdeModulePkg/Bus/Pci/XhciDxe/Xhci.h
@@ -28,6 +28,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/DebugLib.h>
 #include <Library/ReportStatusCodeLib.h>
 #include <Library/TimerLib.h>
+#include <Library/PcdLib.h>
 
 #include <IndustryStandard/Pci.h>
 

--- a/MdeModulePkg/Bus/Pci/XhciDxe/XhciDxe.inf
+++ b/MdeModulePkg/Bus/Pci/XhciDxe/XhciDxe.inf
@@ -56,6 +56,7 @@
   DebugLib
   ReportStatusCodeLib
   TimerLib
+  PcdLib
 
 [Guids]
   gEfiEventExitBootServicesGuid                 ## SOMETIMES_CONSUMES ## Event
@@ -63,6 +64,9 @@
 [Protocols]
   gEfiPciIoProtocolGuid                         ## TO_START
   gEfiUsb2HcProtocolGuid                        ## BY_START
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdDelayXhciHCReset      ## CONSUMES
 
 # [Event]
 # EVENT_TYPE_PERIODIC_TIMER       ## CONSUMES

--- a/MdeModulePkg/Bus/Pci/XhciDxe/XhciReg.c
+++ b/MdeModulePkg/Bus/Pci/XhciDxe/XhciReg.c
@@ -864,7 +864,7 @@ XhcResetHC (
     // Otherwise there may have the timeout case happened.
     // The below is a workaround to solve such problem.
     //
-    gBS->Stall (XHC_1_MILLISECOND);
+    gBS->Stall (PcdGet16 (PcdDelayXhciHCReset));
     Status = XhcWaitOpRegBit (Xhc, XHC_USBCMD_OFFSET, XHC_USBCMD_RESET, FALSE, Timeout);
 
     if (!EFI_ERROR (Status)) {

--- a/MdePkg/MdePkg.dec
+++ b/MdePkg/MdePkg.dec
@@ -2510,5 +2510,9 @@
   # @Prompt Memory encryption attribute
   gEfiMdePkgTokenSpaceGuid.PcdConfidentialComputingGuestAttr|0|UINT64|0x0000002e
 
+  ## This dynamic PCD indicates time delay for XHCI registers access after it issues HCRST.
+  # @Prompt Delay access XHCI register after it issues HCRST (us)
+  gEfiMdePkgTokenSpaceGuid.PcdDelayXhciHCReset|2000|UINT16|0x00000043
+
 [UserExtensions.TianoCore."ExtraFiles"]
   MdePkgExtra.uni

--- a/MdePkg/MdePkg.dsc
+++ b/MdePkg/MdePkg.dsc
@@ -31,6 +31,7 @@
   gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask|0x0f
   gEfiMdePkgTokenSpaceGuid.PcdDebugPrintErrorLevel|0x80000000
   gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseAddress|0xE0000000
+  gEfiMdePkgTokenSpaceGuid.PcdDelayXhciHCReset|2000
 
 [LibraryClasses]
   SafeIntLib|MdePkg/Library/BaseSafeIntLib/BaseSafeIntLib.inf


### PR DESCRIPTION
https://bugzilla.tianocore.org/show_bug.cgi?id=4727

Recently some of XHCI host controllers require to have extra 1ms delay before accessing any MMIO register during reset. PHY transition from P3 to P0 can take around 1.3ms and the xHCI reset can take around 1.5ms. Add PCD to control the delay, the default is 2 ms.

Cc: Hao A Wu     <hao.a.wu@intel.com>
Cc: Ray Ni       <ray.ni@intel.com>
Cc: Jian J Wang  <jian.j.wang@intel.com>
Cc: Liming Gao   <gaoliming@byosoft.com.cn>
Cc: Jenny Huang  <jenny.huang@intel.com>
Cc: More Shih    <more.shih@intel.com>